### PR TITLE
Validation of Arrays

### DIFF
--- a/mandrill.js
+++ b/mandrill.js
@@ -75,7 +75,7 @@ exports.call = (function() {
         
         if(!_api_calls[type][call]) throw "Invalid call";
         
-        if(_.without(opts,_api_calls[type][call]).length > 0) throw "Invalid options passed";
+        if(_.difference(_.keys(opts),_api_calls[type][call]).length > 0) throw "Invalid options passed";
     }
     
     var _callMandrillApi = function(type, call, opts, cb) {


### PR DESCRIPTION
I was getting the "Invalid options passed" error while trying to send an email (it is passing ['key', 'message']).  The current system used the _.without function, which expects an array, then the values.  I changed this to _.difference, and used only the keys of the input array.  This let the email be sent.
